### PR TITLE
Grammar fix: Typo's in days of the week in Dutch

### DIFF
--- a/app/static/custom_js/feiten.js
+++ b/app/static/custom_js/feiten.js
@@ -12,9 +12,9 @@ var NL = d3.locale({
         "date": "%m/%d/%Y",
         "time": "%H:%M:%S",
         "periods": ["AM", "PM"],
-        "days": ["Zondag", "Maandag", "Dinsgag", "Woensdag", "Donderdag", "Vrijdag", "Zaterdag"],
+        "days": ["Zondag", "Maandag", "Dinsdag", "Woensdag", "Donderdag", "Vrijdag", "Zaterdag"],
         "shortDays": ["Zo", "Ma", "Di", "Woe", "Do", "Vrij", "Zat"],
-        "months": ["januarie", "februarie", "Maart", "april", "mei", "juni", "juli", "augustus", "september", "oktober", "november", "december"],
+        "months": ["januari", "februari", "maart", "april", "mei", "juni", "juli", "augustus", "september", "oktober", "november", "december"],
         "shortMonths": ["Jan", "Feb", "Mar", "Apr", "Mei", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dec"]
     });
 


### PR DESCRIPTION
Was looking at the code and found some small typo's.
